### PR TITLE
Add Genesis GV80 first-gen CAN-FD configuration

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc_repo/opendbc/car/hyundai/fingerprints.py
@@ -1281,6 +1281,34 @@ FW_VERSIONS = {
       b'\xf1\x00JX__ RDR -----      1.00 1.03 99110-T6500         ',
     ],
   },
+  # --------------------------------------------------------------------------
+  # Genesis GV80 (CAN-FD)
+  # Expected ECUs on HKG CAN-FD:
+  #   - Forward Radar ECU (SCC):        0x7D0
+  #   - Forward Camera (MFC):           0x7C4
+  #   - Corner Radar (BCW modules):     0x7A1 (typical BCW address on HKG)
+  #
+  # Keep FW strings as raw bytes (b"...") exactly as dumped from the vehicle.
+  # --------------------------------------------------------------------------
+  CAR.GENESIS_GV80_1ST_GEN: {
+    # Forward Radar (SCC) — include all observed variants
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b"\xf1\x00JX1_ SCC -----      1.00 1.03 99110-T6000         ",
+      b"\xf1\x10\x00/\x00\x00",
+    ],
+
+    # Forward Camera (MFC)
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b"\xf1\x00JX1 MFC  AT KOR LHD 1.00 1.04 99211-T6010 200514",
+    ],
+
+    # Corner Radar (BCW) — add each module variant you capture
+    (Ecu.cornerRadar, 0x7a1, None): [
+      b"\xf1\x00JX1 BCW RR 1.00 , 1.04 (q`q \x01\x90R\x06",
+      b"\xf1\x8b  \x07\x13  \x07\x08  \x05\x19  \x05 ",
+    ],
+  },
+
   CAR.GENESIS_G80_PE: {  # (RG3)
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00RG3_ SCC -----      1.00 1.02 99110-T1120         ',

--- a/opendbc_repo/opendbc/car/hyundai/values.py
+++ b/opendbc_repo/opendbc/car/hyundai/values.py
@@ -859,6 +859,31 @@ class CAR(Platforms):
     flags=HyundaiFlags.CANFD_ANGLE_STEERING,
   )
 
+  # --- Hyundai CAN-FD platforms above ---
+
+  # --------------------------------------------------------------------------
+  # Genesis GV80 (1st Gen, CAN-FD)
+  # Platform runs on CAN-FD at 500 kbps arbitration / 2000 kbps data (from log).
+  # steerRatio (13.0) comes directly from liveParameters in the log.
+  # Units:
+  #   - mass in kilograms
+  #   - wheelbase in meters
+  #   - steerRatio is dimensionless
+  #   - tireStiffnessFactor is unitless scaling
+  # NOTE: mass and wheelbase are placeholders until verified against spec/first drive.
+  # --------------------------------------------------------------------------
+  GENESIS_GV80_1ST_GEN = HyundaiCanFDPlatformConfig(
+    # Required harness: Hyundai A
+    [HyundaiCarDocs("Genesis GV80 (1st Gen, CAN-FD)", "All", car_parts=CarParts.common([CarHarness.hyundai_a]))],
+    # Car specifications
+    CarSpecs(
+      mass=2200,        # kg — placeholder, refine after validation
+      wheelbase=2.95,   # m  — placeholder, refine after validation
+      steerRatio=13.0,  # from liveParameters (log)
+      tireStiffnessFactor=0.70  # conservative initial stiffness factor
+    ),
+  )
+
 class Buttons:
   NONE = 0
   RES_ACCEL = 1

--- a/opendbc_repo/opendbc/car/torque_data/override.toml
+++ b/opendbc_repo/opendbc/car/torque_data/override.toml
@@ -85,3 +85,10 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "KIA_EV6_PE" = [nan, 2.5, nan]
 "GENESIS_GV70_PE" = [nan, 2.5, nan]
 "GENESIS_GV80_PE" = [nan, 2.5, nan]
+# --------------------------------------------------------------------------
+# Genesis GV80 initial lateral torque tuning
+# Format: [kp, ki, feedforward]
+# These values are unitless tuning parameters.
+# Conservative initial tuning, adjust later with on-road logs.
+# --------------------------------------------------------------------------
+"GENESIS_GV80_1ST_GEN" = [2.30, 2.30, 0.10]


### PR DESCRIPTION
## Summary
- add Genesis GV80 1st gen CAN-FD platform with initial specs
- supply initial torque tuning parameters
- record firmware fingerprints for radar, camera and corner radar